### PR TITLE
Fix JSON-LD datePublished format

### DIFF
--- a/src/app/[id]/post-client-page.tsx
+++ b/src/app/[id]/post-client-page.tsx
@@ -42,7 +42,7 @@ export default function PostClientPage({
         url: '',
       },
     },
-    datePublished: createDate,
+    datePublished: new Date(createDate).toISOString(),
   };
 
   useGoogleAnalytics();


### PR DESCRIPTION
## Summary
- Convert JSON-LD datePublished from millisecond timestamp to ISO 8601 string

## Verification
- npm run tsc
- npm run lint
- Checked local DOM output: datePublished is an ISO 8601 string

Closes #66