### PR TITLE
fix: render markdown code blocks without language

### DIFF
--- a/src/components/atoms/CodeBlock/index.tsx
+++ b/src/components/atoms/CodeBlock/index.tsx
@@ -4,10 +4,10 @@ import { tomorrow } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 // NOTE: Syntax highlighter は value という props が必須
 type Props = {
   value: string;
-  language: string;
+  language?: string;
 };
 
-const CodeBlock = ({ value, language }: Props) => {
+const CodeBlock = ({ value, language = '' }: Props) => {
   return (
     <SyntaxHighlighter
       language={language}

--- a/src/components/atoms/TextItem/index.stories.tsx
+++ b/src/components/atoms/TextItem/index.stories.tsx
@@ -21,6 +21,6 @@ type Story = StoryObj<typeof TextItem>;
 
 export const Default: Story = {
   args: {
-    text: 'list item',
+    children: 'list item',
   },
 };

--- a/src/components/atoms/TextItem/index.tsx
+++ b/src/components/atoms/TextItem/index.tsx
@@ -1,11 +1,13 @@
+import { ReactNode } from 'react';
+
 import * as Styles from './index.css';
 
 type Props = {
-  text: string;
+  children: ReactNode;
 };
 
-const TextItem = ({ text }: Props) => {
-  return <li className={Styles.base}>{text}</li>;
+const TextItem = ({ children }: Props) => {
+  return <li className={Styles.base}>{children}</li>;
 };
 
 export default TextItem;

--- a/src/components/atoms/TextList/index.stories.tsx
+++ b/src/components/atoms/TextList/index.stories.tsx
@@ -16,9 +16,9 @@ export const Default: Story = {
   args: {
     children: (
       <>
-        <TextItem text="hello" />
-        <TextItem text="goodbye" />
-        <TextItem text="thanks" />
+        <TextItem>hello</TextItem>
+        <TextItem>goodbye</TextItem>
+        <TextItem>thanks</TextItem>
       </>
     ),
   },

--- a/src/components/organisms/Markdown/index.tsx
+++ b/src/components/organisms/Markdown/index.tsx
@@ -45,11 +45,11 @@ const Markdown = ({ content }: Props) => {
         code({ inline, className, children }) {
           const match = /language-(\w+)/.exec(className || '');
 
-          if (!inline && match) {
+          if (!inline) {
             return (
               <CodeBlock
                 value={extractTextFromChildren(children)}
-                language={match[1]}
+                language={match?.[1]}
               />
             );
           }
@@ -58,7 +58,6 @@ const Markdown = ({ content }: Props) => {
             return <InlineCode text={extractTextFromChildren(children)} />;
           }
 
-          // NOTE: どの条件にも一致しない時に null を返さないとエラーを起こす
           return null;
         },
         img({ src, alt }) {
@@ -81,7 +80,7 @@ const Markdown = ({ content }: Props) => {
           );
         },
         li({ children }) {
-          return <TextItem text={extractTextFromChildren(children)} />;
+          return <TextItem>{children}</TextItem>;
         },
         h2({ children }) {
           return (


### PR DESCRIPTION
## Summary
- Render fenced code blocks even when markdown has no language hint
- Normalize missing CodeBlock language to an empty string for react-syntax-highlighter
- Preserve rich inline markdown content inside list items

## Verification
- npm run tsc
- npm run lint
- Browser checked /wquzQz1bXSe1s7Vy6lTG and /ugrMrZbDM2a4DfVHwfkb

Closes #80